### PR TITLE
remove no-longer-supported syntax

### DIFF
--- a/cfr-decompiler.rb
+++ b/cfr-decompiler.rb
@@ -4,8 +4,6 @@ class CfrDecompiler < Formula
   url "https://www.benf.org/other/cfr/cfr-0.149.jar"
   sha256 "db683b5b3bc2c20fd2fabcc9d749d5b8bcbba736f334e5ac2092173242967aca"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   def install

--- a/jenv.rb
+++ b/jenv.rb
@@ -5,8 +5,6 @@ class Jenv < Formula
   sha256 "a038ab91962c8a1b14391eb383fc6472468c56338526a406f486e9ff6c794dbc"
   head "https://github.com/dwijnand/jenv.git"
 
-  bottle :unneeded
-
   def install
     libexec.install Dir["*"]
     bin.write_exec_script libexec/"bin/jenv"

--- a/scala@2.10.rb
+++ b/scala@2.10.rb
@@ -6,8 +6,6 @@ class ScalaAT210 < Formula
   mirror "https://www.scala-lang.org/files/archive/scala-2.10.7.tgz"
   sha256 "9283119916f6bb7714e076a2840ccf22d58819b355228ed1591ae6f76929f111"
 
-  bottle :unneeded
-
   keg_only :versioned_formula
 
   depends_on "openjdk@8"


### PR DESCRIPTION
references dwijnand/scala-runners#42

hopefully fixes this:

```
Error: Invalid formula: /opt/homebrew/Library/Taps/dwijnand/homebrew-formulas/cfr-decompiler.rb
cfr-decompiler: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the dwijnand/formulas tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/dwijnand/homebrew-formulas/cfr-decompiler.rb:7

Error: Invalid formula: /opt/homebrew/Library/Taps/dwijnand/homebrew-formulas/scala@2.10.rb
scala@2.10: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the dwijnand/formulas tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/dwijnand/homebrew-formulas/scala@2.10.rb:9

Error: Invalid formula: /opt/homebrew/Library/Taps/dwijnand/homebrew-formulas/jenv.rb
jenv: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the dwijnand/formulas tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/dwijnand/homebrew-formulas/jenv.rb:8
```