### PR TITLE
Update scala-runners.rb

### DIFF
--- a/scala-runners.rb
+++ b/scala-runners.rb
@@ -3,7 +3,7 @@ class ScalaRunners < Formula
   homepage "https://github.com/dwijnand/scala-runners"
   head 'git://github.com/dwijnand/scala-runners.git', :branch => "main"
 
-  depends_on "coursier/formulas/coursier"
+  depends_on "coursier"
 
   def install
     bin.install Dir["scala*"]


### PR DESCRIPTION
I'm not certain this is a correct change. but the following transcript seems like evidence that it should be changed?

```
% brew install --HEAD --no-binaries dwijnand/formulas/scala-runners
==> Downloading https://github.com/coursier/coursier/releases/download/v2.1.0-M5-18-gfebf9838c/cours
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/37
######################################################################## 100.0%
==> Downloading https://github.com/coursier/coursier/releases/download/v2.1.0-M5-18-gfebf9838c/cs-x8
Already downloaded: /Users/tisue/Library/Caches/Homebrew/downloads/e56f4bc31b6326034ab85448faa48e50054affc7b327e3e82180fc861633fc54--cs-x86_64-apple-darwin.gz
==> Cloning git://github.com/dwijnand/scala-runners.git
Updating /Users/tisue/Library/Caches/Homebrew/scala-runners--git
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
HEAD is now at dc1ad83 Switch to eq 0 || die, so setScalaVersion exits with 0
==> Installing scala-runners from dwijnand/formulas
==> Installing dependencies for dwijnand/formulas/scala-runners: coursier/formulas/coursier
Error: coursier is already installed from homebrew/core!
Please `brew uninstall coursier` first."
```
